### PR TITLE
chore(terraform)!: pin AWS provider to ~> 6.0

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
- Change: required_providers.aws version from ">= 4.0" to "~> 6.0"
- Reason: lock to AWS provider 6.x for predictable upgrades
- Impact: consumers on provider 4.x or 5.x must upgrade before using this module

BREAKING CHANGE: AWS provider constraint is now "~> 6.0". Upgrade the hashicorp/aws provider to 6.x in your root module before upgrading.