### PR TITLE
revert: "chore(terraform)!: pin AWS provider to ~> 6.0 (#5)"

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
This reverts commit c52d5801ff2f55af16e55cb03891bea0a6bbcbd0.