### PR TITLE
ci(pipeline): move terraform-docs to PR workflow

### DIFF
--- a/.github/workflows/module-documentation.yml
+++ b/.github/workflows/module-documentation.yml
@@ -1,0 +1,17 @@
+name: Generate terraform docs
+on:
+  - pull_request
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Render terraform docs inside the README.md and push changes back to PR branch
+        uses: terraform-docs/gh-actions@v1
+        with:
+          config-file: .terraform-docs.yml
+          git-push: true
+          git-push-sign-off: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,19 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Render terraform docs inside the README.md
-        uses: terraform-docs/gh-actions@v1
-        with:
-          config-file: .terraform-docs.yml
-          git-push: true
-
   release-please:
-    needs: docs
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
- Added module-documentation workflow to run terraform-docs on PRs, generating and pushing README changes back to the PR branch
- Removed docs job from release-please workflow since documentation is already up-to-date by the time code merges to main