### PR TITLE
chore(terraform)!: pin AWS provider to ~> 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Return values from AWS Parameter Store using by path data block in a friendly fo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: AWS provider constraint changed from >= 4.0 to ~> 6.0. Module users must use AWS provider v6.x in their root module.