### PR TITLE
ci(release): add GITHUB_TOKEN to release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           release-type: terraform-module


### PR DESCRIPTION
Enables release-please to create release PRs and tags using the default GitHub Actions token.