### PR TITLE
feat(config): add recursive option for parameter path retrieval

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 data "aws_ssm_parameters_by_path" "parameters" {
-  path = var.path
+  path      = var.path
+  recursive = var.recursive
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,9 @@ variable "path" {
     error_message = "Path must start with / and end with /."
   }
 }
+
+variable "recursive" {
+  description = "Whether to retrieve all parameters under the path recursively."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- Resource: data.aws_ssm_parameters_by_path.parameters
- Change: add recursive argument driven by new var.recursive
- Reason: allow retrieving all parameters under path recursively
- Impact: backward compatible (default false); set true for nested paths